### PR TITLE
Updated parameter in start-log from dash to hyphen

### DIFF
--- a/Module/PSLogging/PSLogging.psm1
+++ b/Module/PSLogging/PSLogging.psm1
@@ -88,7 +88,7 @@ Function Start-Log {
     }
 
     #Create file and start logging
-    New-Item -Path $sFullPath –ItemType File
+    New-Item -Path $sFullPath -ItemType File
 
     Add-Content -Path $sFullPath -Value "***************************************************************************************************"
     Add-Content -Path $sFullPath -Value "Started processing at [$([DateTime]::Now)]."


### PR DESCRIPTION
Hi,

Noticed when implementing logging in Powershell 7 that the **New-Item** command in **Start-Log** was failing with the below. Seems like it was a dash of some kind instead of a hyphen which PowerShell Core seems to be picky about whereas it works fine in Powershell 5.1

``` PowerShell
New-Item: C:\Users\camer\Documents\PowerShell\Modules\PSLogging\2.5.2\PSLogging.psm1:91
Line |
  91 |      New-Item -Path $sFullPath �ItemType File
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | A positional parameter cannot be found that accepts argument '�ItemType'.
```