### PR TITLE
 - Loads... See description for details.

### DIFF
--- a/Module/PSLogging/PSLogging.psm1
+++ b/Module/PSLogging/PSLogging.psm1
@@ -5,6 +5,44 @@
 
 Set-StrictMode -Version Latest
 
+Enum PSLoggingState
+{
+  Stopped
+  Started
+}
+
+# Init State
+Set-Variable -Name PSLoggingState -Value Stopped -Option allscope -Scope Global | Out-Null
+
+<#
+  .SYNOPSIS
+    Print Exception
+
+  .DESCRIPTION
+    Print Exception Details
+#>
+
+function Script:PrintPSLoggingException{
+    [CmdletBinding(SupportsShouldProcess)]
+    Param
+    (
+        [Parameter(Mandatory=$true)]
+        [System.Management.Automation.ErrorRecord]$Record,
+        [Parameter(Mandatory=$false)]
+        [switch]$ShowStack
+    )       
+    $formatstring = "{0}`n{1}"
+    $fields = $Record.FullyQualifiedErrorId,$Record.Exception.ToString()
+    $ExceptMsg=($formatstring -f $fields)
+    $Stack=$Record.ScriptStackTrace
+    Write-Host "[PSLogging] -> " -NoNewLine -ForegroundColor Red; 
+    Write-Host "$ExceptMsg" -ForegroundColor Yellow
+    if($ShowStack){
+        Write-Host "--stack begin--" -ForegroundColor Green
+        Write-Host "$Stack" -ForegroundColor Gray  
+        Write-Host "--stack end--`n" -ForegroundColor Green       
+    }
+} 
 
 Function Start-Log {
   <#
@@ -18,15 +56,8 @@ Function Start-Log {
   .PARAMETER LogPath
     Mandatory. Path of where log is to be created. Example: C:\Windows\Temp
 
-  .PARAMETER LogName
-    Mandatory. Name of log file to be created. Example: Test_Script.log
-
   .PARAMETER ScriptVersion
     Mandatory. Version of the running script which will be written in the log. Example: 1.5
-
-  .PARAMETER ToScreen
-    Optional. When parameter specified will display the content to screen as well as write to log file. This provides an additional
-    another option to write content to screen as opposed to using debug mode.
 
   .INPUTS
     Parameters above
@@ -60,6 +91,11 @@ Function Start-Log {
     Creation Date:  12/09/15
     Purpose/Change: Added -ToScreen parameter which will display content to screen as well as write to the log file.
 
+    Version:        1.4.1
+    Author:         cybercastor
+    Creation Date:  2021-11-20 11:22
+    Purpose/Change: MINOR STUFF AND POLISHING Reference: https://github.com/9to5IT/PSLogging/pull/15/commits
+
   .LINK
     http://9to5IT.com/powershell-logging-v2-easily-create-log-files
 
@@ -70,57 +106,63 @@ Function Start-Log {
     the date and time the log was created (or the calling script started executing) and the calling script's version.
   #>
 
-  [CmdletBinding()]
+  [CmdletBinding(SupportsShouldProcess)]
 
   Param (
-    [Parameter(Mandatory=$true,Position=0)][string]$LogPath,
-    [Parameter(Mandatory=$true,Position=1)][string]$LogName,
-    [Parameter(Mandatory=$true,Position=2)][string]$ScriptVersion,
-    [Parameter(Mandatory=$false,Position=3)][switch]$ToScreen
+    
+    [ValidateScript({
+      if($_ | Test-Path -PathType Container){
+          throw "The Path argument must be a File. Directory paths are not allowed."
+      }
+      if($_ | Test-Path ) {
+          throw "File already exists"
+      }
+      return $True
+    })]
+    [Parameter(Mandatory=$true,Position=0)]
+    [Alias('f','file')]
+    [string]$LogPath,  
+    [Parameter(Mandatory=$true)]
+    [Alias('v','ver')]
+    [string]$ScriptVersion
   )
 
-  Process {
-    $sFullPath = Join-Path -Path $LogPath -ChildPath $LogName
+  
+    try{
+      If ( $Global:PSLoggingState -eq [PSLoggingState]::Started ){
+        throw "Already Started"
+      }
+      #Create file and start logging
+      New-Item -Path $LogPath -ItemType File -Force -EA Stop | Out-Null
 
-    #Check if file exists and delete if it does
-    If ( (Test-Path -Path $sFullPath) ) {
-      Remove-Item -Path $sFullPath -Force
+      Set-Variable -Name PSLoggingState -Value Started -Option allscope -Scope Global | Out-Null
+      Set-Variable -Name PSLoggingLogFile -Value $LogPath -Option allscope,readonly -Scope Global -Force | Out-Null
+      
+      Add-Content -Path $LogPath -Value "***************************************************************************************************"
+      Add-Content -Path $LogPath -Value "Started processing at [$([DateTime]::Now)]."
+      Add-Content -Path $LogPath -Value "***************************************************************************************************"
+      Add-Content -Path $LogPath -Value ""
+      Add-Content -Path $LogPath -Value "Running script version [$ScriptVersion]."
+      Add-Content -Path $LogPath -Value ""
+      Add-Content -Path $LogPath -Value "***************************************************************************************************"
+      Add-Content -Path $LogPath -Value ""
+
+      #Write to scren for ToScreen mode
+      If ( $PSBoundParameters.ContainsKey('Verbose') -eq $True ){
+        Write-Output "***************************************************************************************************"
+        Write-Output "Started processing at [$([DateTime]::Now)]."
+        Write-Output "***************************************************************************************************"
+        Write-Output ""
+        Write-Output "Running script version [$ScriptVersion]."
+        Write-Output ""
+        Write-Output "***************************************************************************************************"
+        Write-Output ""
+    }
+    
+    }catch [Exception]{
+        PrintPSLoggingException($_) -ShowStack
     }
 
-    #Create file and start logging
-    New-Item -Path $sFullPath –ItemType File
-
-    Add-Content -Path $sFullPath -Value "***************************************************************************************************"
-    Add-Content -Path $sFullPath -Value "Started processing at [$([DateTime]::Now)]."
-    Add-Content -Path $sFullPath -Value "***************************************************************************************************"
-    Add-Content -Path $sFullPath -Value ""
-    Add-Content -Path $sFullPath -Value "Running script version [$ScriptVersion]."
-    Add-Content -Path $sFullPath -Value ""
-    Add-Content -Path $sFullPath -Value "***************************************************************************************************"
-    Add-Content -Path $sFullPath -Value ""
-
-    #Write to screen for debug mode
-    Write-Debug "***************************************************************************************************"
-    Write-Debug "Started processing at [$([DateTime]::Now)]."
-    Write-Debug "***************************************************************************************************"
-    Write-Debug ""
-    Write-Debug "Running script version [$ScriptVersion]."
-    Write-Debug ""
-    Write-Debug "***************************************************************************************************"
-    Write-Debug ""
-
-    #Write to scren for ToScreen mode
-    If ( $ToScreen -eq $True ) {
-      Write-Output "***************************************************************************************************"
-      Write-Output "Started processing at [$([DateTime]::Now)]."
-      Write-Output "***************************************************************************************************"
-      Write-Output ""
-      Write-Output "Running script version [$ScriptVersion]."
-      Write-Output ""
-      Write-Output "***************************************************************************************************"
-      Write-Output ""
-    }
-  }
 }
 
 Function Write-LogInfo {
@@ -131,19 +173,16 @@ Function Write-LogInfo {
   .DESCRIPTION
     Appends a new informational message to the specified log file
 
-  .PARAMETER LogPath
-    Mandatory. Full path of the log file you want to write to. Example: C:\Windows\Temp\Test_Script.log
-
   .PARAMETER Message
     Mandatory. The string that you want to write to the log
+
+  .PARAMETER LogPath
+    Optional. Full path of the log file you want to write to. Example: C:\Windows\Temp\Test_Script.log
+    Can be specified in Start-Log
 
   .PARAMETER TimeStamp
     Optional. When parameter specified will append the current date and time to the end of the line. Useful for knowing
     when a task started and stopped.
-
-  .PARAMETER ToScreen
-    Optional. When parameter specified will display the content to screen as well as write to log file. This provides an additional
-    another option to write content to screen as opposed to using debug mode.
 
   .INPUTS
     Parameters above
@@ -182,6 +221,11 @@ Function Write-LogInfo {
     Creation Date:  12/09/15
     Purpose/Change: Added -ToScreen parameter which will display content to screen as well as write to the log file.
 
+    Version:        1.5.1
+    Author:         cybercastor
+    Creation Date:  2021-11-20 11:22
+    Purpose/Change: MINOR STUFF AND POLISHING Reference: https://github.com/9to5IT/PSLogging/pull/15/commits
+
   .LINK
     http://9to5IT.com/powershell-logging-v2-easily-create-log-files
 
@@ -191,31 +235,39 @@ Function Write-LogInfo {
     Writes a new informational log message to a new line in the specified log file.
   #>
 
-  [CmdletBinding()]
+  [CmdletBinding(SupportsShouldProcess)]
 
   Param (
-    [Parameter(Mandatory=$true,Position=0)][string]$LogPath,
-    [Parameter(Mandatory=$true,Position=1,ValueFromPipeline=$true)][string]$Message,
-    [Parameter(Mandatory=$false,Position=2)][switch]$TimeStamp,
-    [Parameter(Mandatory=$false,Position=3)][switch]$ToScreen
+    [Parameter(Mandatory=$true,Position=0,ValueFromPipeline=$true)][string]$Message,
+    [Parameter(Mandatory=$false,Position=1)]
+    [Alias('f','file')]
+    [string]$LogPath,
+    [Parameter(Mandatory=$false,Position=2)]
+    [Alias('t','time')]
+    [switch]$TimeStamp
   )
 
-  Process {
-    #Add TimeStamp to message if specified
-    If ( $TimeStamp -eq $True ) {
-      $Message = "$Message  [$([DateTime]::Now)]"
-    }
+  try{
+      If ( $PSBoundParameters.ContainsKey('LogPath') -eq $False ) {
+        if( $Global:PSLoggingState -eq [PSLoggingState]::Stopped ){
+          throw "Need to specify the LogPath (or call Log-Start)"
+        }else{
+          $LogPath = $Global:PSLoggingLogFile
+        }
+      }
+      #Add TimeStamp to message if specified
+      If ( $TimeStamp -eq $True ) {
+        $Message = "[$([DateTime]::Now.GetDateTimeFormats()[19])] $Message"
+      }
 
-    #Write Content to Log
-    Add-Content -Path $LogPath -Value $Message
+      $Message = "[INFO]`t$Message"
 
-    #Write to screen for debug mode
-    Write-Debug $Message
+      If ( $PSBoundParameters.ContainsKey('Verbose') -eq $True ) { Write-Output $Message }
+      #Write Content to Log
+      Add-Content -Path $LogPath -Value $Message
 
-    #Write to scren for ToScreen mode
-    If ( $ToScreen -eq $True ) {
-      Write-Output $Message
-    }
+  }catch [Exception]{
+    PrintPSLoggingException($_)
   }
 }
 
@@ -227,19 +279,15 @@ Function Write-LogWarning {
   .DESCRIPTION
     Appends a new warning message to the specified log file. Automatically prefixes line with WARNING:
 
-  .PARAMETER LogPath
-    Mandatory. Full path of the log file you want to write to. Example: C:\Windows\Temp\Test_Script.log
-
   .PARAMETER Message
     Mandatory. The string that you want to write to the log
+
+  .PARAMETER LogPath
+    Optional. Full path of the log file you want to write to. Example: C:\Windows\Temp\Test_Script.log
 
   .PARAMETER TimeStamp
     Optional. When parameter specified will append the current date and time to the end of the line. Useful for knowing
     when a task started and stopped.
-
-  .PARAMETER ToScreen
-    Optional. When parameter specified will display the content to screen as well as write to log file. This provides an additional
-    another option to write content to screen as opposed to using debug mode.
 
   .INPUTS
     Parameters above
@@ -263,6 +311,11 @@ Function Write-LogWarning {
     Creation Date:  12/09/15
     Purpose/Change: Added -ToScreen parameter which will display content to screen as well as write to the log file.
 
+    Version:        1.2.1
+    Author:         cybercastor
+    Creation Date:  2021-11-20 11:22
+    Purpose/Change: MINOR STUFF AND POLISHING Reference: https://github.com/9to5IT/PSLogging/pull/15/commits
+
   .LINK
     http://9to5IT.com/powershell-logging-v2-easily-create-log-files
 
@@ -272,31 +325,42 @@ Function Write-LogWarning {
     Writes a new warning log message to a new line in the specified log file.
   #>
 
-  [CmdletBinding()]
+  [CmdletBinding(SupportsShouldProcess)]
 
   Param (
-    [Parameter(Mandatory=$true,Position=0)][string]$LogPath,
     [Parameter(Mandatory=$true,Position=1,ValueFromPipeline=$true)][string]$Message,
-    [Parameter(Mandatory=$false,Position=2)][switch]$TimeStamp,
-    [Parameter(Mandatory=$false,Position=3)][switch]$ToScreen
+    [Parameter(Mandatory=$false)]
+    [Alias('f','file')]
+    [string]$LogPath,
+    [Parameter(Mandatory=$false)]
+    [Alias('t','time')]
+    [switch]$TimeStamp
   )
+  try{
 
-  Process {
+    
+    If ( $PSBoundParameters.ContainsKey('LogPath') -eq $False ) {
+      if( $Global:PSLoggingState -eq [PSLoggingState]::Stopped ){
+        throw "Need to specify the LogPath (or call Log-Start)"
+      }else{
+        $LogPath = $Global:PSLoggingLogFile
+      }
+    }
     #Add TimeStamp to message if specified
     If ( $TimeStamp -eq $True ) {
-      $Message = "$Message  [$([DateTime]::Now)]"
+      $Message = "[$([DateTime]::Now.GetDateTimeFormats()[19])] $Message"
     }
+    If ( $PSBoundParameters.ContainsKey('Verbose') -eq $True ){ Write-Warning $Message }
+
+    $Message = "[WARN]`t$Message"
 
     #Write Content to Log
-    Add-Content -Path $LogPath -Value "WARNING: $Message"
+    Add-Content -Path $LogPath -Value $Message
 
-    #Write to screen for debug mode
-    Write-Debug "WARNING: $Message"
+    
 
-    #Write to scren for ToScreen mode
-    If ( $ToScreen -eq $True ) {
-      Write-Output "WARNING: $Message"
-    }
+  }catch [Exception]{
+        PrintPSLoggingException($_)
   }
 }
 
@@ -318,12 +382,8 @@ Function Write-LogError {
     Optional. When parameter specified will append the current date and time to the end of the line. Useful for knowing
     when a task started and stopped.
 
-  .PARAMETER ExitGracefully
-    Optional. If parameter specified, then runs Stop-Log and then exits script
-
-  .PARAMETER ToScreen
-    Optional. When parameter specified will display the content to screen as well as write to log file. This provides an additional
-    another option to write content to screen as opposed to using debug mode.
+  .PARAMETER Exception
+    Optional. If parameter specified, throw an exception
 
   .INPUTS
     Parameters above
@@ -372,6 +432,11 @@ Function Write-LogError {
     Creation Date:  12/09/15
     Purpose/Change: Added -ToScreen parameter which will display content to screen as well as write to the log file.
 
+    Version:        1.7.1
+    Author:         cybercastor
+    Creation Date:  2021-11-20 11:22
+    Purpose/Change: MINOR STUFF AND POLISHING Reference: https://github.com/9to5IT/PSLogging/pull/15/commits
+
   .LINK
     http://9to5IT.com/powershell-logging-v2-easily-create-log-files
 
@@ -391,39 +456,45 @@ Function Write-LogError {
     Note: If you don't specify the -ExitGracefully parameter, then the script will not exit on error.
   #>
 
-  [CmdletBinding()]
+  [CmdletBinding(SupportsShouldProcess)]
 
   Param (
-    [Parameter(Mandatory=$true,Position=0)][string]$LogPath,
-    [Parameter(Mandatory=$true,Position=1,ValueFromPipeline=$true)][string]$Message,
-    [Parameter(Mandatory=$false,Position=3)][switch]$TimeStamp,
-    [Parameter(Mandatory=$false,Position=4)][switch]$ExitGracefully,
-    [Parameter(Mandatory=$false,Position=5)][switch]$ToScreen
+    [Parameter(Mandatory=$true,Position=0,ValueFromPipeline=$true)][string]$Message,
+    [Parameter(Mandatory=$false)]
+    [Alias('f','file')]
+    [string]$LogPath,
+    [Parameter(Mandatory=$false)]
+    [Alias('t','time')]
+    [switch]$TimeStamp,
+    [Parameter(Mandatory=$false)]
+    [Alias('e')]
+    [switch]$Exception
   )
+    try{
 
-  Process {
+     If ( $PSBoundParameters.ContainsKey('LogPath') -eq $False ) {
+      if( $Global:PSLoggingState -eq [PSLoggingState]::Stopped ){
+        throw "Need to specify the LogPath (or call Log-Start)"
+      }else{
+        $LogPath = $Global:PSLoggingLogFile
+      }
+    }
+
     #Add TimeStamp to message if specified
     If ( $TimeStamp -eq $True ) {
-      $Message = "$Message  [$([DateTime]::Now)]"
+      $Message = "[$([DateTime]::Now.GetDateTimeFormats()[19])] $Message"
     }
-
+    If ( $PSBoundParameters.ContainsKey('Verbose') -eq $True ){ Write-Error $Message }
+    $Message = "[ERRO]`t$Message"
     #Write Content to Log
-    Add-Content -Path $LogPath -Value "ERROR: $Message"
+    Add-Content -Path $LogPath -Value $Message
 
-    #Write to screen for debug mode
-    Write-Debug "ERROR: $Message"
-
-    #Write to scren for ToScreen mode
-    If ( $ToScreen -eq $True ) {
-      Write-Output "ERROR: $Message"
+    If ( $Exception -eq $True ) {
+      throw $Message
     }
 
-    #If $ExitGracefully = True then run Log-Finish and exit script
-    If ( $ExitGracefully -eq $True ){
-      Add-Content -Path $LogPath -Value " "
-      Stop-Log -LogPath $LogPath
-      Break
-    }
+  }catch [Exception]{
+      PrintPSLoggingException($_)
   }
 }
 
@@ -434,16 +505,6 @@ Function Stop-Log {
 
   .DESCRIPTION
     Writes finishing logging data to specified log file and then exits the calling script
-
-  .PARAMETER LogPath
-    Mandatory. Full path of the log file you want to write finishing data to. Example: C:\Windows\Temp\Test_Script.log
-
-  .PARAMETER NoExit
-    Optional. If parameter specified, then the function will not exit the calling script, so that further execution can occur (like Send-Log)
-
-  .PARAMETER ToScreen
-    Optional. When parameter specified will display the content to screen as well as write to log file. This provides an additional
-    another option to write content to screen as opposed to using debug mode.
 
   .INPUTS
     Parameters above
@@ -482,6 +543,11 @@ Function Stop-Log {
     Creation Date:  12/09/15
     Purpose/Change: Added -ToScreen parameter which will display content to screen as well as write to the log file.
 
+    Version:        1.4.1
+    Author:         cybercastor
+    Creation Date:  2021-11-20 11:22
+    Purpose/Change: MINOR STUFF AND POLISHING Reference: https://github.com/9to5IT/PSLogging/pull/15/commits
+
   .LINK
     http://9to5IT.com/powershell-logging-v2-easily-create-log-files
 
@@ -500,38 +566,28 @@ Function Stop-Log {
     Send-Log function to email the created log to users).
   #>
 
-  [CmdletBinding()]
+  [CmdletBinding(SupportsShouldProcess)]
+  Param ()
+  try{
+      If ( $Global:PSLoggingState -eq [PSLoggingState]::Stopped ){
+        throw "Already Stopped"
+      }
+      Set-Variable -Name PSLoggingState -Value [PSLoggingState]::Stopped -Option allscope -Scope Global | Out-Null
+      $LogPath = $Global:PSLoggingLogFile
 
-  Param (
-    [Parameter(Mandatory=$true,Position=0)][string]$LogPath,
-    [Parameter(Mandatory=$false,Position=1)][switch]$NoExit,
-    [Parameter(Mandatory=$false,Position=2)][switch]$ToScreen
-  )
+      Add-Content -Path $LogPath -Value ""
+      Add-Content -Path $LogPath -Value "***************************************************************************************************"
+      Add-Content -Path $LogPath -Value "Finished processing at [$([DateTime]::Now)]."
+      Add-Content -Path $LogPath -Value "***************************************************************************************************"
 
-  Process {
-    Add-Content -Path $LogPath -Value ""
-    Add-Content -Path $LogPath -Value "***************************************************************************************************"
-    Add-Content -Path $LogPath -Value "Finished processing at [$([DateTime]::Now)]."
-    Add-Content -Path $LogPath -Value "***************************************************************************************************"
-
-    #Write to screen for debug mode
-    Write-Debug ""
-    Write-Debug "***************************************************************************************************"
-    Write-Debug "Finished processing at [$([DateTime]::Now)]."
-    Write-Debug "***************************************************************************************************"
-
-    #Write to scren for ToScreen mode
-    If ( $ToScreen -eq $True ) {
-      Write-Output ""
-      Write-Output "***************************************************************************************************"
-      Write-Output "Finished processing at [$([DateTime]::Now)]."
-      Write-Output "***************************************************************************************************"
-    }
-
-    #Exit calling script if NoExit has not been specified or is set to False
-    If( !($NoExit) -or ($NoExit -eq $False) ){
-      Exit
-    }
+      If ( $PSBoundParameters.ContainsKey('Verbose') -eq $True ){
+        Write-Output ""
+        Write-Output "***************************************************************************************************"
+        Write-Output "Finished processing at [$([DateTime]::Now)]."
+        Write-Output "***************************************************************************************************"
+      }
+  }catch [Exception]{
+        PrintPSLoggingException($_)
   }
 }
 
@@ -546,9 +602,6 @@ Function Send-Log {
   .PARAMETER SMTPServer
     Mandatory. FQDN of the SMTP server used to send the email. Example: smtp.google.com
 
-  .PARAMETER LogPath
-    Mandatory. Full path of the log file you want to email. Example: C:\Windows\Temp\Test_Script.log
-
   .PARAMETER EmailFrom
     Mandatory. The email addresses of who you want to send the email from. Example: "admin@9to5IT.com"
 
@@ -557,6 +610,11 @@ Function Send-Log {
 
   .PARAMETER EmailSubject
     Mandatory. The subject of the email you want to send. Example: "Cool Script - [" + (Get-Date).ToShortDateString() + "]"
+
+  .PARAMETER LogPath
+    NOT Mandatory. Full path of the log file you want to email, or if not specified the log file use in the last session.,
+    which means, the one called in Log-Start. 
+    Example: C:\Windows\Temp\Test_Script.log
 
   .INPUTS
     Parameters above
@@ -591,28 +649,45 @@ Function Send-Log {
     sent using the smtp.google.com SMTP server.
   #>
 
-  [CmdletBinding()]
-
+  [CmdletBinding(SupportsShouldProcess)]
   Param (
-    [Parameter(Mandatory=$true,Position=0)][string]$SMTPServer,
-    [Parameter(Mandatory=$true,Position=1)][string]$LogPath,
-    [Parameter(Mandatory=$true,Position=2)][string]$EmailFrom,
-    [Parameter(Mandatory=$true,Position=3)][string]$EmailTo,
-    [Parameter(Mandatory=$true,Position=4)][string]$EmailSubject
+    [Parameter(Mandatory=$true,Position=0)]
+    [Alias('smtp')]
+    [string]$SMTPServer,
+    [Parameter(Mandatory=$true,Position=1)]
+    [Alias('from')]
+    [string]$EmailFrom,
+    [Parameter(Mandatory=$true,Position=2)]
+    [Alias('to')]
+    [string]$EmailTo,
+    [Parameter(Mandatory=$true,Position=3)]
+    [Alias('subject')]
+    [string]$EmailSubject,
+    [Parameter(Mandatory=$false,Position=4)]
+    [ValidateScript({
+        if(-Not ($_ | Test-Path) ){
+            throw "File does not exist"
+        }
+        if(-Not ($_ | Test-Path -PathType Leaf) ){
+            throw "The Path argument must be a file. Directory paths are not allowed."
+        }
+        return $true 
+    })]
+    [string]$LogPath
   )
 
-  Process {
-    Try {
+  try {
+      If ( $PSBoundParameters.ContainsKey('LogPath') -eq $False ){
+        $LogPath = $Global:PSLoggingLogFile
+      }
       $sBody = ( Get-Content $LogPath | Out-String )
 
       #Create SMTP object and send email
       $oSmtp = new-object Net.Mail.SmtpClient( $SMTPServer )
       $oSmtp.Send( $EmailFrom, $EmailTo, $EmailSubject, $sBody )
       Exit 0
-    }
-
-    Catch {
-      Exit 1
-    }
+  }catch [Exception]{
+        PrintPSLoggingException($_)
   }
+
 }


### PR DESCRIPTION
 - Removed Write-DEBUG..... why?
 - Added exception error management
 - Removed 'LogName' argument: repetitive
 - TimeStamp at the beginning and changed Timestamp format
 - Added LogState (Stopped/Started). LogPath argument now optional when caling Write-*
 - Remove mandatory order in arguments for flags
 - ToScreen:  Remove 'ToScreen' argument: using 'Verbose' only
 CORRECT PIPING
 - ToScreen:  The Output to screen uses Write-Warning / Write-Error instead of Write-Output
 - Added Aliases [Alias('f','file')] for LogPath and [Alias('t','time')] for timestamp

 Start-Log -f 'C:\Temp\TestScript.log' -ScriptVersion '1.0'
 Write-LogInfo 'This'
 Write-LogWarning 'Is' -t -Verbose
 Write-LogError 'less argument' -time
 Write-LogInfo 'repetition'
 Stop-Log
 # Send last session
 Send-Log 'smtp.google.com' 'me' 'you' 'logs'
 Send-Log 'smtp.google.com' 'me' 'you' 'more logs' 'c:\OtherLogs.txt'